### PR TITLE
Add npmrc to remove package locking

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Package locks are the root of all evil.

This pull request adds a `.npmrc` file to not create `package-lock.json`.